### PR TITLE
Re-export public facing enums from SocksCore

### DIFF
--- a/Sources/Socks/Socks.swift
+++ b/Sources/Socks/Socks.swift
@@ -7,3 +7,5 @@
 //
 
 @_exported import struct SocksCore.InternetAddress
+@_exported import enum SocksCore.Port
+@_exported import enum SocksCore.AddressFamily


### PR DESCRIPTION
Fixes #32
