### PR TITLE
Refactoring + fixed NOSIGPIPE (with tests)

### DIFF
--- a/Sources/Socks/SynchronousTCPServer.swift
+++ b/Sources/Socks/SynchronousTCPServer.swift
@@ -23,7 +23,7 @@ public class SynchronousTCPServer {
     
     @noreturn public func startWithHandler(handler: (client: TCPClient) throws -> ()) throws {
         
-        let server = try TCPSocket(address: address)
+        let server = try TCPInternetSocket(address: address)
         try server.bind()
         try server.listen(queueLimit: 4096)
         

--- a/Sources/Socks/SynchronousUDPServer.swift
+++ b/Sources/Socks/SynchronousUDPServer.swift
@@ -23,7 +23,7 @@ public class SynchronousUDPServer {
     
     @noreturn public func startWithHandler(handler: (received: [UInt8], client: UDPClient) throws -> ()) throws {
         
-        let server = try UDPSocket(address: address)
+        let server = try UDPInternetSocket(address: address)
         try server.bind()
         
         while true {

--- a/Sources/Socks/TCPClient.swift
+++ b/Sources/Socks/TCPClient.swift
@@ -10,23 +10,23 @@ import SocksCore
 
 public class TCPClient {
     
-    public let socket: TCPSocket
+    public let socket: TCPInternetSocket
     
     public func ipAddress() -> String {
         return self.socket.address.ipString()
     }
     
-    public init(alreadyConnectedSocket: TCPSocket) throws {
+    public init(alreadyConnectedSocket: TCPInternetSocket) throws {
         self.socket = alreadyConnectedSocket
     }
 
-    public convenience init(socket: TCPSocket) throws {
+    public convenience init(socket: TCPInternetSocket) throws {
         try self.init(alreadyConnectedSocket: socket)
         try self.socket.connect()
     }
     
     public convenience init(address: InternetAddress) throws {
-        let socket = try TCPSocket(address: address)
+        let socket = try TCPInternetSocket(address: address)
         try self.init(socket: socket)
     }
     

--- a/Sources/Socks/UDPClient.swift
+++ b/Sources/Socks/UDPClient.swift
@@ -10,24 +10,24 @@ import SocksCore
 
 public class UDPClient {
     
-    public let socket: UDPSocket
+    public let socket: UDPInternetSocket
     
     public func ipAddress() -> String {
         return self.socket.address.ipString()
     }
     
-    public init(socket: UDPSocket) throws {
+    public init(socket: UDPInternetSocket) throws {
         self.socket = socket
     }
     
     public convenience init(address: InternetAddress) throws {
-        let socket = try UDPSocket(address: address)
+        let socket = try UDPInternetSocket(address: address)
         try self.init(socket: socket)
     }
     
     public convenience init(address: ResolvedInternetAddress) throws {
         let config: SocketConfig = .UDP(addressFamily: try address.addressFamily())
-        let socket = try UDPSocket(descriptor: nil, config: config, address: address)
+        let socket = try UDPInternetSocket(descriptor: nil, config: config, address: address)
         try self.init(socket: socket)
     }
     

--- a/Sources/SocksCore/Address+C.swift
+++ b/Sources/SocksCore/Address+C.swift
@@ -62,14 +62,14 @@ struct Resolver: InternetAddressResolver{
         var servinfo = UnsafeMutablePointer<socket_addrinfo>.init(nil)
         // perform resolution
         let ret = getaddrinfo(internetAddress.hostname, internetAddress.port.toString(), &addressCriteria, &servinfo)
-        guard ret == 0 else { throw Error(.IPAddressValidationFailed) }
+        guard ret == 0 else { throw Error(.ipAddressValidationFailed) }
         
-        guard let addrList = servinfo else { throw Error(.IPAddressResolutionFailed) }
+        guard let addrList = servinfo else { throw Error(.ipAddressResolutionFailed) }
         
         //this takes the first resolved address, potentially we should
         //get all of the addresses in the list and allow for iterative
         //connecting
-        guard let addrInfo = addrList.pointee.ai_addr else { throw Error(.IPAddressResolutionFailed) }
+        guard let addrInfo = addrList.pointee.ai_addr else { throw Error(.ipAddressResolutionFailed) }
         let family = try AddressFamily(fromCType: Int32(addrInfo.pointee.sa_family))
         
         let ptr = UnsafeMutablePointer<sockaddr_storage>(allocatingCapacity: 1)
@@ -85,7 +85,7 @@ struct Resolver: InternetAddressResolver{
             let specPtr = UnsafeMutablePointer<sockaddr_in6>(ptr)
             specPtr.assignFrom(addr, count: 1)
         default:
-            throw Error.init(ErrorReason.ConcreteSocketAddressFamilyRequired)
+            throw Error(.concreteSocketAddressFamilyRequired)
         }
         
         let address = ResolvedInternetAddress(raw: ptr)

--- a/Sources/SocksCore/Bytes.swift
+++ b/Sources/SocksCore/Bytes.swift
@@ -56,7 +56,7 @@ extension Collection where Iterator.Element == UInt8 {
             case .emptyInput: //we're done
                 return str
             case .error: //error, can't describe what however
-                throw Error.init(ErrorReason.UnparsableBytes)
+                throw Error(.unparsableBytes)
             case .scalarValue(let unicodeScalar):
                 str.append(unicodeScalar)
             }

--- a/Sources/SocksCore/Error.swift
+++ b/Sources/SocksCore/Error.swift
@@ -14,28 +14,29 @@
 
 public enum ErrorReason {
     
-    case CreateSocketFailed
-    case OptionSetFailed(level: Int32, name: Int32, value: String)
-    case OptionGetFailed(level: Int32, name: Int32, type: String)
-    case CloseSocketFailed
+    case createSocketFailed
+    case optionSetFailed(level: Int32, name: Int32, value: String)
+    case optionGetFailed(level: Int32, name: Int32, type: String)
+    case closeSocketFailed
     
-    case IPAddressValidationFailed
-    case FailedToGetIPFromHostname(String)
-    case UnparsableBytes
+    case pipeCreationFailed
     
-    case ConnectFailed
-    case SendFailedToSendAllBytes
-    case ReadFailed
-    case BindFailed
-    case ListenFailed
-    case AcceptFailed
+    case ipAddressResolutionFailed
+    case ipAddressValidationFailed
+    case failedToGetIPFromHostname(String)
+    case unparsableBytes
     
-    case UnsupportedSocketAddressFamily(Int32)
-    case ConcreteSocketAddressFamilyRequired
+    case connectFailed
+    case sendFailedToSendAllBytes
+    case readFailed
+    case bindFailed
+    case listenFailed
+    case acceptFailed
     
-    case IPAddressResolutionFailed
+    case unsupportedSocketAddressFamily(Int32)
+    case concreteSocketAddressFamilyRequired
     
-    case Generic(String)
+    case generic(String)
 }
 
 //see error codes: https://gist.github.com/czechboy0/517b22041c0eeb33f723bb66933882e4
@@ -50,7 +51,7 @@ public struct Error: ErrorProtocol, CustomStringConvertible {
     }
     
     init(_ message: String) {
-        self.type = .Generic(message)
+        self.type = .generic(message)
         self.number = -1
     }
     

--- a/Sources/SocksCore/InternetSocket.swift
+++ b/Sources/SocksCore/InternetSocket.swift
@@ -24,6 +24,6 @@ extension InternetSocket {
     
     public func bind() throws {
         let res = socket_bind(self.descriptor, address.raw, address.rawLen)
-        guard res > -1 else { throw Error(.BindFailed) }
+        guard res > -1 else { throw Error(.bindFailed) }
     }
 }

--- a/Sources/SocksCore/Pipe.swift
+++ b/Sources/SocksCore/Pipe.swift
@@ -1,0 +1,27 @@
+#if os(Linux)
+    import Glibc
+    let socket_socketpair = Glibc.socketpair
+#else
+    import Darwin
+    let socket_socketpair = Darwin.socketpair
+#endif
+
+public protocol Pipeable {
+    static func pipe() throws -> (read: TCPReadableSocket, write: TCPWriteableSocket)
+}
+
+extension TCPEstablishedSocket: Pipeable {
+    
+    public static func pipe() throws -> (read: TCPReadableSocket, write: TCPWriteableSocket) {
+        var descriptors: [Descriptor] = [0, 0]
+        guard socket_socketpair(AF_LOCAL, SOCK_STREAM, 0, &descriptors) != -1 else {
+            throw Error(.pipeCreationFailed)
+        }
+        try descriptors.forEach {
+            try TCPEstablishedSocket.disableSIGPIPE(descriptor: $0)
+        }
+        let read = TCPEstablishedReadableSocket(descriptor: descriptors[0])
+        let write = TCPEstablishedWriteableSocket(descriptor: descriptors[1])
+        return (read, write)
+    }
+}

--- a/Sources/SocksCore/Pipe.swift
+++ b/Sources/SocksCore/Pipe.swift
@@ -14,7 +14,8 @@ extension TCPEstablishedSocket: Pipeable {
     
     public static func pipe() throws -> (read: TCPReadableSocket, write: TCPWriteableSocket) {
         var descriptors: [Descriptor] = [0, 0]
-        guard socket_socketpair(AF_LOCAL, SOCK_STREAM, 0, &descriptors) != -1 else {
+        let socketType = SocketType.stream.toCType()
+        guard socket_socketpair(AF_LOCAL, socketType, 0, &descriptors) != -1 else {
             throw Error(.pipeCreationFailed)
         }
         try descriptors.forEach {

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -64,7 +64,7 @@ extension TCPWriteableSocket {
     
     public func send(data: [UInt8]) throws {
         let len = data.count
-        let flags = Int32(SO_NOSIGPIPE) //FIXME: allow setting flags with a Swift enum
+        let flags = Int32(SOCKET_NOSIGNAL) //FIXME: allow setting flags with a Swift enum
         let sentLen = socket_send(self.descriptor, data, len, flags)
         guard sentLen == len else { throw Error(.sendFailedToSendAllBytes) }
     }

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -15,6 +15,7 @@
     private let socket_recv = Glibc.recv
     private let socket_send = Glibc.send
     private let socket_close = Glibc.close
+    private let SOCKET_NOSIGNAL = Glibc.MSG_NOSIGNAL
 #else
     import Darwin
     private let socket_connect = Darwin.connect
@@ -24,41 +25,22 @@
     private let socket_recv = Darwin.recv
     private let socket_send = Darwin.send
     private let socket_close = Darwin.close
+    private let SOCKET_NOSIGNAL = Darwin.SO_NOSIGPIPE
 #endif
 
+public protocol TCPSocket: RawSocket { }
 
-public class TCPSocket: InternetSocket {
+public protocol TCPWriteableSocket: TCPSocket { }
 
-    public let descriptor: Descriptor
-    public let config: SocketConfig
-    public let address: ResolvedInternetAddress
-    public var closed: Bool
+public protocol TCPReadableSocket: TCPSocket { }
 
-    public required init(descriptor: Descriptor?, config: SocketConfig, address: ResolvedInternetAddress) throws {
-        if let descriptor = descriptor {
-            self.descriptor = descriptor
-        } else {
-            self.descriptor = try TCPSocket.createNewSocket(config: config)
-        }
-        self.config = config
-        self.address = address
-        self.closed = false
-        
-        self.reuseAddress = true
-    }
-    
-    public convenience init(address: InternetAddress) throws {
-        var conf: SocketConfig = .TCP(addressFamily: address.addressFamily)
-        let resolved = try address.resolve(with: conf)
-        try conf.adjust(for: resolved)
-        try self.init(descriptor: nil, config: conf, address: resolved)
-    }
+extension TCPReadableSocket {
     
     public func recv(maxBytes: Int = BufferCapacity) throws -> [UInt8] {
         let data = Bytes(capacity: maxBytes)
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
         let receivedBytes = socket_recv(self.descriptor, data.rawBytes, data.capacity, flags)
-        guard receivedBytes > -1 else { throw Error(.ReadFailed) }
+        guard receivedBytes > -1 else { throw Error(.readFailed) }
         let finalBytes = data.characters[0..<receivedBytes]
         let out = Array(finalBytes.map({ UInt8($0) }))
         return out
@@ -76,45 +58,84 @@ public class TCPSocket: InternetSocket {
         }
         return buffer
     }
+}
+
+extension TCPWriteableSocket {
     
     public func send(data: [UInt8]) throws {
         let len = data.count
-        let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
+        let flags = Int32(SO_NOSIGPIPE) //FIXME: allow setting flags with a Swift enum
         let sentLen = socket_send(self.descriptor, data, len, flags)
-        guard sentLen == len else { throw Error(.SendFailedToSendAllBytes) }
+        guard sentLen == len else { throw Error(.sendFailedToSendAllBytes) }
+    }
+}
+
+public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TCPWriteableSocket {
+
+    public let descriptor: Descriptor
+    public let config: SocketConfig
+    public let address: ResolvedInternetAddress
+    public var closed: Bool
+
+    public required init(descriptor: Descriptor?, config: SocketConfig, address: ResolvedInternetAddress) throws {
+        if let descriptor = descriptor {
+            self.descriptor = descriptor
+        } else {
+            self.descriptor = try TCPInternetSocket.createNewSocket(config: config)
+        }
+        self.config = config
+        self.address = address
+        self.closed = false
+        
+        self.reuseAddress = true
+    }
+    
+    public convenience init(address: InternetAddress) throws {
+        var conf: SocketConfig = .TCP(addressFamily: address.addressFamily)
+        let resolved = try address.resolve(with: conf)
+        try conf.adjust(for: resolved)
+        try self.init(descriptor: nil, config: conf, address: resolved)
     }
     
     public func connect() throws {
         let res = socket_connect(self.descriptor, address.raw, address.rawLen)
-        guard res > -1 else { throw Error(.ConnectFailed) }
+        guard res > -1 else { throw Error(.connectFailed) }
     }
 
     public func listen(queueLimit: Int32 = 4096) throws {
         let res = socket_listen(self.descriptor, queueLimit)
-        guard res > -1 else { throw Error(.ListenFailed) }
+        guard res > -1 else { throw Error(.listenFailed) }
     }
     
-    public func accept() throws -> TCPSocket {
-
+    public func accept() throws -> TCPInternetSocket {
         var length = socklen_t(sizeof(sockaddr_storage))
         let addr = UnsafeMutablePointer<sockaddr_storage>.init(allocatingCapacity: 1)
         let addrSockAddr = UnsafeMutablePointer<sockaddr>(addr)
-        
         let clientSocketDescriptor = socket_accept(self.descriptor, addrSockAddr, &length)
-        
-        guard clientSocketDescriptor > -1 else { throw Error(.AcceptFailed) }
-        
+        guard clientSocketDescriptor > -1 else { throw Error(.acceptFailed) }
         let clientAddress = ResolvedInternetAddress(raw: addr)
-        
-        let clientSocket = try TCPSocket(descriptor: clientSocketDescriptor, config: config, address: clientAddress)
+        let clientSocket = try TCPInternetSocket(descriptor: clientSocketDescriptor,
+                                                 config: config,
+                                                 address: clientAddress)
         return clientSocket
     }
-
 
     public func close() throws {
         closed = true
         if socket_close(self.descriptor) != 0 {
-            throw Error(.CloseSocketFailed)
+            throw Error(.closeSocketFailed)
         }
     }
 }
+
+public class TCPEstablishedSocket: TCPSocket {
+    
+    public let descriptor: Descriptor
+    
+    public init(descriptor: Descriptor) {
+        self.descriptor = descriptor
+    }
+}
+
+public class TCPEstablishedWriteableSocket: TCPEstablishedSocket, TCPWriteableSocket { }
+public class TCPEstablishedReadableSocket: TCPEstablishedSocket, TCPReadableSocket { }

--- a/Sources/SocksCore/Types.swift
+++ b/Sources/SocksCore/Types.swift
@@ -135,7 +135,7 @@ extension AddressFamily {
         case Int32(AF_INET): self = .inet
         case Int32(AF_INET6): self = .inet6
         case Int32(AF_UNSPEC): self = .unspecified
-        default: throw Error(.UnsupportedSocketAddressFamily(cType))
+        default: throw Error(.unsupportedSocketAddressFamily(cType))
         }
     }
 }

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -16,7 +16,7 @@
     private let socket_sendto = Darwin.sendto
 #endif
 
-public class UDPSocket: InternetSocket {
+public class UDPInternetSocket: InternetSocket {
     
     public let descriptor: Descriptor
     public let config: SocketConfig
@@ -27,7 +27,7 @@ public class UDPSocket: InternetSocket {
         if let descriptor = descriptor {
             self.descriptor = descriptor
         } else {
-            self.descriptor = try UDPSocket.createNewSocket(config: config)
+            self.descriptor = try UDPInternetSocket.createNewSocket(config: config)
         }
         self.config = config
         self.address = address
@@ -58,7 +58,7 @@ public class UDPSocket: InternetSocket {
             addrSockAddr,
             &length
         )
-        guard receivedBytes > -1 else { throw Error(.ReadFailed) }
+        guard receivedBytes > -1 else { throw Error(.readFailed) }
         
         let clientAddress = ResolvedInternetAddress(raw: addr)
         
@@ -80,6 +80,6 @@ public class UDPSocket: InternetSocket {
             destination.raw,
             destination.rawLen
         )
-        guard sentLen == len else { throw Error(.SendFailedToSendAllBytes) }
+        guard sentLen == len else { throw Error(.sendFailedToSendAllBytes) }
     }
 }

--- a/Sources/SocksCoreExampleTCPClient/main.swift
+++ b/Sources/SocksCoreExampleTCPClient/main.swift
@@ -7,7 +7,7 @@ let address = InternetAddress(hostname: "google.com", port: .portNumber(80))
 //let address = InternetAddress(hostname: "216.58.214.206", port: .portNumber(80))
 
 do {
-    let socket: TCPSocket = try TCPSocket(address: address)
+    let socket = try TCPInternetSocket(address: address)
     try socket.connect()
     
     //sends a GET / request to google.com at port 80, expects a 302 redirect to HTTPS

--- a/Sources/SocksCoreExampleTCPServer/main.swift
+++ b/Sources/SocksCoreExampleTCPServer/main.swift
@@ -3,7 +3,7 @@ import SocksCore
 do {
     //let address = InternetAddress.any(port: 8080, ipVersion: .inet6)
     let address = InternetAddress.any(port: 8080)
-    let socket = try TCPSocket(address: address)
+    let socket = try TCPInternetSocket(address: address)
     
     try socket.bind()
     try socket.listen()

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,5 +4,6 @@ import XCTest
 XCTMain([
 	testCase(AddressResolutionTests.allTests),
 	testCase(ConversionTests.allTests),
-	testCase(LiveTests.allTests)
+	testCase(LiveTests.allTests),
+	testCase(PipeTests.allTests)
 ])

--- a/Tests/SocksCore/LiveTests.swift
+++ b/Tests/SocksCore/LiveTests.swift
@@ -15,7 +15,7 @@ class LiveTests: XCTestCase {
         
         let addr = InternetAddress(hostname: "google.com",
                                    port: .portNumber(80))
-        let socket = try TCPSocket(address: addr)
+        let socket = try TCPInternetSocket(address: addr)
         
         try socket.connect()
         

--- a/Tests/SocksCore/PipeTests.swift
+++ b/Tests/SocksCore/PipeTests.swift
@@ -1,0 +1,45 @@
+//
+//  PipeTests.swift
+//  Socks
+//
+//  Created by Honza Dvorsky on 6/8/16.
+//
+//
+
+import XCTest
+@testable import SocksCore
+
+class PipeTests: XCTestCase {
+    
+    func testSendAndReceive() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        let msg = "Hello Socket".toBytes()
+        try write.send(data: msg)
+        let inMsg = try read.recv().toString()
+        try read.close()
+        try write.close()
+        XCTAssertEqual(inMsg, "Hello Socket")
+    }
+    
+    func testNoData() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        try read.close()
+        try write.close()
+    }
+    
+    func testNoSIGPIPE() throws {
+        
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        try read.close()
+
+        let msg = "Hello Socket".toBytes()
+
+        XCTAssertThrowsError(try write.send(data: msg)) { (error) in
+            let err = error as! SocksCore.Error
+            XCTAssertEqual(err.number, 32) //broken pipe
+        }
+        
+        try write.close()
+    }
+
+}

--- a/Tests/SocksCore/XCTestManifests.swift
+++ b/Tests/SocksCore/XCTestManifests.swift
@@ -30,3 +30,13 @@ extension LiveTests {
     }
 }
 
+extension PipeTests {
+    static var allTests : [(String, (PipeTests) -> () throws -> Void)] {
+        return [
+            ("testSendAndReceive", testSendAndReceive),
+            ("testNoData", testNoData),
+            ("testNoSIGPIPE", testNoSIGPIPE)
+        ]
+    }
+}
+


### PR DESCRIPTION
- renamed TCPSocket to TCPInternetSocket (TCPSocket is now a protocol that encompasses even non-internet TCP sockets) - same for UDP
- added pipe() to allow for local testing by creating two connected sockets - useful for testing
- disabled SIGPIPE on all created sockets, tested in tests (that's where pipe() becomes useful)
- added a few very basic pipe tests, more will come in later PRs, this allows us to test the lower-level logic much more easily

Fixes #37, replaces #43.

/cc @tannernelson
