### PR TITLE
Added select() to observe activity on multiple sockets, more tests

### DIFF
--- a/Sources/SocksCore/Error.swift
+++ b/Sources/SocksCore/Error.swift
@@ -21,6 +21,8 @@ public enum ErrorReason {
     
     case pipeCreationFailed
     
+    case selectFailed(reads: [Descriptor], writes: [Descriptor], errors: [Descriptor])
+    
     case ipAddressResolutionFailed
     case ipAddressValidationFailed
     case failedToGetIPFromHostname(String)

--- a/Sources/SocksCore/FDSet.swift
+++ b/Sources/SocksCore/FDSet.swift
@@ -1,0 +1,159 @@
+// Copyright (c) 2016, Kyle Fuller
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+
+func fdZero(_ set: inout fd_set) {
+#if os(Linux)
+  set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#else
+  set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#endif
+}
+
+
+func fdSet(_ descriptor: Descriptor, _ set: inout fd_set) {
+#if os(Linux)
+  let intOffset = Int(descriptor / 16)
+  let bitOffset = Int(descriptor % 16)
+  let mask = 1 << bitOffset
+  switch intOffset {
+    case 0: set.__fds_bits.0 = set.__fds_bits.0 | mask
+    case 1: set.__fds_bits.1 = set.__fds_bits.1 | mask
+    case 2: set.__fds_bits.2 = set.__fds_bits.2 | mask
+    case 3: set.__fds_bits.3 = set.__fds_bits.3 | mask
+    case 4: set.__fds_bits.4 = set.__fds_bits.4 | mask
+    case 5: set.__fds_bits.5 = set.__fds_bits.5 | mask
+    case 6: set.__fds_bits.6 = set.__fds_bits.6 | mask
+    case 7: set.__fds_bits.7 = set.__fds_bits.7 | mask
+    case 8: set.__fds_bits.8 = set.__fds_bits.8 | mask
+    case 9: set.__fds_bits.9 = set.__fds_bits.9 | mask
+    case 10: set.__fds_bits.10 = set.__fds_bits.10 | mask
+    case 11: set.__fds_bits.11 = set.__fds_bits.11 | mask
+    case 12: set.__fds_bits.12 = set.__fds_bits.12 | mask
+    case 13: set.__fds_bits.13 = set.__fds_bits.13 | mask
+    case 14: set.__fds_bits.14 = set.__fds_bits.14 | mask
+    case 15: set.__fds_bits.15 = set.__fds_bits.15 | mask
+    default: break
+  }
+#else
+  let intOffset = Int32(descriptor / 16)
+  let bitOffset = Int32(descriptor % 16)
+  let mask: Int32 = 1 << bitOffset
+
+  switch intOffset {
+    case 0: set.fds_bits.0 = set.fds_bits.0 | mask
+    case 1: set.fds_bits.1 = set.fds_bits.1 | mask
+    case 2: set.fds_bits.2 = set.fds_bits.2 | mask
+    case 3: set.fds_bits.3 = set.fds_bits.3 | mask
+    case 4: set.fds_bits.4 = set.fds_bits.4 | mask
+    case 5: set.fds_bits.5 = set.fds_bits.5 | mask
+    case 6: set.fds_bits.6 = set.fds_bits.6 | mask
+    case 7: set.fds_bits.7 = set.fds_bits.7 | mask
+    case 8: set.fds_bits.8 = set.fds_bits.8 | mask
+    case 9: set.fds_bits.9 = set.fds_bits.9 | mask
+    case 10: set.fds_bits.10 = set.fds_bits.10 | mask
+    case 11: set.fds_bits.11 = set.fds_bits.11 | mask
+    case 12: set.fds_bits.12 = set.fds_bits.12 | mask
+    case 13: set.fds_bits.13 = set.fds_bits.13 | mask
+    case 14: set.fds_bits.14 = set.fds_bits.14 | mask
+    case 15: set.fds_bits.15 = set.fds_bits.15 | mask
+    default: break
+  }
+#endif
+}
+
+
+func fdIsSet(_ descriptor: Descriptor, _ set: inout fd_set) -> Bool {
+#if os(Linux)
+  let intOffset = Int(descriptor / 32)
+  let bitOffset = Int(descriptor % 32)
+  let mask = Int(1 << bitOffset)
+
+  switch intOffset {
+    case 0: return set.__fds_bits.0 & mask != 0
+    case 1: return set.__fds_bits.1 & mask != 0
+    case 2: return set.__fds_bits.2 & mask != 0
+    case 3: return set.__fds_bits.3 & mask != 0
+    case 4: return set.__fds_bits.4 & mask != 0
+    case 5: return set.__fds_bits.5 & mask != 0
+    case 6: return set.__fds_bits.6 & mask != 0
+    case 7: return set.__fds_bits.7 & mask != 0
+    case 8: return set.__fds_bits.8 & mask != 0
+    case 9: return set.__fds_bits.9 & mask != 0
+    case 10: return set.__fds_bits.10 & mask != 0
+    case 11: return set.__fds_bits.11 & mask != 0
+    case 12: return set.__fds_bits.12 & mask != 0
+    case 13: return set.__fds_bits.13 & mask != 0
+    case 14: return set.__fds_bits.14 & mask != 0
+    case 15: return set.__fds_bits.15 & mask != 0
+    default: return false
+  }
+#else
+  let intOffset = Int32(descriptor / 32)
+  let bitOffset = Int32(descriptor % 32)
+  let mask = Int32(1 << bitOffset)
+
+  switch intOffset {
+    case 0: return set.fds_bits.0 & mask != 0
+    case 1: return set.fds_bits.1 & mask != 0
+    case 2: return set.fds_bits.2 & mask != 0
+    case 3: return set.fds_bits.3 & mask != 0
+    case 4: return set.fds_bits.4 & mask != 0
+    case 5: return set.fds_bits.5 & mask != 0
+    case 6: return set.fds_bits.6 & mask != 0
+    case 7: return set.fds_bits.7 & mask != 0
+    case 8: return set.fds_bits.8 & mask != 0
+    case 9: return set.fds_bits.9 & mask != 0
+    case 10: return set.fds_bits.10 & mask != 0
+    case 11: return set.fds_bits.11 & mask != 0
+    case 12: return set.fds_bits.12 & mask != 0
+    case 13: return set.fds_bits.13 & mask != 0
+    case 14: return set.fds_bits.14 & mask != 0
+    case 15: return set.fds_bits.15 & mask != 0
+    case 16: return set.fds_bits.16 & mask != 0
+    case 17: return set.fds_bits.17 & mask != 0
+    case 18: return set.fds_bits.18 & mask != 0
+    case 19: return set.fds_bits.19 & mask != 0
+    case 20: return set.fds_bits.20 & mask != 0
+    case 21: return set.fds_bits.21 & mask != 0
+    case 22: return set.fds_bits.22 & mask != 0
+    case 23: return set.fds_bits.23 & mask != 0
+    case 24: return set.fds_bits.24 & mask != 0
+    case 25: return set.fds_bits.25 & mask != 0
+    case 26: return set.fds_bits.26 & mask != 0
+    case 27: return set.fds_bits.27 & mask != 0
+    case 28: return set.fds_bits.28 & mask != 0
+    case 29: return set.fds_bits.29 & mask != 0
+    case 30: return set.fds_bits.30 & mask != 0
+    case 31: return set.fds_bits.31 & mask != 0
+    default: return false
+  }
+#endif
+}

--- a/Sources/SocksCore/Select.swift
+++ b/Sources/SocksCore/Select.swift
@@ -1,0 +1,82 @@
+// Copyright (c) 2016, Kyle Fuller
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(Linux)
+    import Glibc
+    private let system_select = Glibc.select
+#else
+    import Darwin
+    private let system_select = Darwin.select
+#endif
+
+extension timeval {
+    public init(seconds: Int) {
+        self = timeval(tv_sec: seconds, tv_usec: 0)
+    }
+}
+
+private func filter(_ sockets: [Descriptor]?, _ set: inout fd_set) -> [Descriptor] {
+    return sockets?.filter {
+        fdIsSet($0, &set)
+        } ?? []
+}
+
+public func select(reads: [Descriptor] = [],
+                   writes: [Descriptor] = [],
+                   errors: [Descriptor] = [],
+                   timeout: timeval? = nil) throws
+    -> (reads: [Descriptor], writes: [Descriptor], errors: [Descriptor]) {
+        
+    var readFDs = fd_set()
+    fdZero(&readFDs)
+    reads.forEach { fdSet($0, &readFDs) }
+    
+    var writeFDs = fd_set()
+    fdZero(&writeFDs)
+    writes.forEach { fdSet($0, &writeFDs) }
+    
+    var errorFDs = fd_set()
+    fdZero(&errorFDs)
+    errors.forEach { fdSet($0, &errorFDs) }
+    
+    let maxFD = (reads + writes + errors).reduce(0, combine: max)
+    let result: Int32
+    if let timeout = timeout {
+        var timeout = timeout
+        result = system_select(maxFD + 1, &readFDs, &writeFDs, &errorFDs, &timeout)
+    } else {
+        result = system_select(maxFD + 1, &readFDs, &writeFDs, &errorFDs, nil)
+    }
+    
+    if result == 0 {
+        return ([], [], [])
+    } else if result > 0 {
+        return (
+            filter(reads, &readFDs),
+            filter(writes, &writeFDs),
+            filter(errors, &errorFDs)
+        )
+    }
+    throw Error(.selectFailed(reads: reads, writes: writes, errors: errors))
+}

--- a/Sources/SocksCore/Select.swift
+++ b/Sources/SocksCore/Select.swift
@@ -24,11 +24,15 @@
 
 #if os(Linux)
     import Glibc
+    @_exported import struct Glibc.timeval
     private let system_select = Glibc.select
 #else
     import Darwin
+    @_exported import struct Darwin.timeval
     private let system_select = Darwin.select
 #endif
+
+
 
 extension timeval {
     public init(seconds: Int) {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,5 +5,6 @@ XCTMain([
 	testCase(AddressResolutionTests.allTests),
 	testCase(ConversionTests.allTests),
 	testCase(LiveTests.allTests),
-	testCase(PipeTests.allTests)
+	testCase(PipeTests.allTests),
+	testCase(SelectTests.allTests)
 ])

--- a/Tests/SocksCore/SelectTests.swift
+++ b/Tests/SocksCore/SelectTests.swift
@@ -1,0 +1,74 @@
+//
+//  SelectTests.swift
+//  Socks
+//
+//  Created by Honza Dvorsky on 6/8/16.
+//
+//
+
+import XCTest
+@testable import SocksCore
+
+class SelectTests: XCTestCase {
+    
+    func testEmpties() throws {
+        let (reads, writes, errors) = try select(timeout: timeval(seconds: 0))
+        XCTAssertEqual(reads.count, 0)
+        XCTAssertEqual(writes.count, 0)
+        XCTAssertEqual(errors.count, 0)
+    }
+    
+    func testOnePipeReadyToWrite() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        let (reads, writes, errors) = try select(reads: [read.descriptor],
+                                                 writes: [write.descriptor],
+                                                 errors: [],
+                                                 timeout: timeval(seconds: 0))
+        try read.close()
+        try write.close()
+        XCTAssertEqual(reads.count, 0)
+        XCTAssertEqual(writes.count, 1)
+        XCTAssertEqual(writes[0], write.descriptor)
+        XCTAssertEqual(errors.count, 0)
+    }
+    
+    func testOnePipeReadyToReadOneToWrite() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        try write.send(data: "Heya".toBytes())
+        let (reads, writes, errors) = try select(reads: [read.descriptor],
+                                                 writes: [write.descriptor],
+                                                 errors: [],
+                                                 timeout: timeval(seconds: 0))
+        try read.close()
+        try write.close()
+        
+        XCTAssertEqual(reads.count, 1)
+        XCTAssertEqual(reads[0], read.descriptor)
+        XCTAssertEqual(writes.count, 1)
+        XCTAssertEqual(errors.count, 0)
+    }
+    
+    func testTwoPipesReadyToRead() throws {
+        let (read1, write1) = try TCPEstablishedSocket.pipe()
+        let (read2, write2) = try TCPEstablishedSocket.pipe()
+        let (read3, write3) = try TCPEstablishedSocket.pipe()
+        try write1.send(data: "Heya".toBytes())
+        try write3.send(data: "Socks".toBytes())
+        let (reads, writes, errors) = try select(reads: [read1.descriptor, read2.descriptor, read3.descriptor],
+                                                 writes: [],
+                                                 errors: [],
+                                                 timeout: timeval(seconds: 0))
+        try read1.close()
+        try write1.close()
+        try read2.close()
+        try write2.close()
+        try read3.close()
+        try write3.close()
+        
+        XCTAssertEqual(reads.count, 2)
+        XCTAssertEqual(Set(reads), Set([read1.descriptor, read3.descriptor]))
+        XCTAssertEqual(writes.count, 0)
+        XCTAssertEqual(errors.count, 0)
+    }
+
+}

--- a/Tests/SocksCore/XCTestManifests.swift
+++ b/Tests/SocksCore/XCTestManifests.swift
@@ -40,3 +40,15 @@ extension PipeTests {
     }
 }
 
+extension SelectTests {
+    static var allTests : [(String, (SelectTests) -> () throws -> Void)] {
+        return [
+            ("testEmpties", testEmpties),
+            ("testOnePipeReadyToWrite", testOnePipeReadyToWrite),
+            ("testOnePipeReadyToReadOneToWrite", testOnePipeReadyToReadOneToWrite),
+            ("testTwoPipesReadyToRead", testTwoPipesReadyToRead)
+        ]
+    }
+}
+
+


### PR DESCRIPTION
This PR adds `select()`, useful for observing activity on multiple sockets, probably crucial if you want to implement proper keepAlive on your server (instead of closing each client connection after serving one request, just keep it around and watch for more incoming data on the socket, close when the headers tell you to or when no activity has been observed from the socket for a long time)

Might be more efficient solution for Vapor, @tannernelson (instead of blocking one thread per connection)
