### PR TITLE
Bugfixes, refactoring

### DIFF
--- a/Sources/Socks/Socks.swift
+++ b/Sources/Socks/Socks.swift
@@ -7,6 +7,6 @@
 //
 
 @_exported import struct SocksCore.InternetAddress
-@_exported import enum SocksCore.Port
+@_exported import typealias SocksCore.Port
 @_exported import enum SocksCore.AddressFamily
 @_exported import typealias SocksCore.Descriptor

--- a/Sources/SocksCore/Conversions.swift
+++ b/Sources/SocksCore/Conversions.swift
@@ -8,7 +8,7 @@
 
 //convert little-endian to big-endian for network transfer
 //aka Host TO Network Short
-func htons(value: CUnsignedShort) -> CUnsignedShort {
+func htons(_ value: CUnsignedShort) -> CUnsignedShort {
     return (value << 8) + (value >> 8)
 }
 

--- a/Sources/SocksCore/Error.swift
+++ b/Sources/SocksCore/Error.swift
@@ -23,6 +23,8 @@ public enum ErrorReason {
     
     case selectFailed(reads: [Descriptor], writes: [Descriptor], errors: [Descriptor])
     
+    case localAddressResolutionFailed
+    case remoteAddressResolutionFailed
     case ipAddressResolutionFailed
     case ipAddressValidationFailed
     case failedToGetIPFromHostname(String)

--- a/Sources/SocksCore/Select.swift
+++ b/Sources/SocksCore/Select.swift
@@ -84,3 +84,14 @@ public func select(reads: [Descriptor] = [],
     }
     throw Error(.selectFailed(reads: reads, writes: writes, errors: errors))
 }
+
+extension RawSocket {
+    
+    /// Allows user to wait for the socket to have readable bytes for
+    /// up to the specified timeout. Nil timeout means wait forever.
+    /// Returns true if data is ready to be read, false if timed out.
+    public func waitForReadableData(timeout: timeval?) throws -> Bool {
+        let (readables, _, _) = try select(reads: [descriptor], timeout: timeout)
+        return !readables.isEmpty
+    }
+}

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -112,7 +112,10 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
         let addr = UnsafeMutablePointer<sockaddr_storage>.init(allocatingCapacity: 1)
         let addrSockAddr = UnsafeMutablePointer<sockaddr>(addr)
         let clientSocketDescriptor = socket_accept(self.descriptor, addrSockAddr, &length)
-        guard clientSocketDescriptor > -1 else { throw Error(.acceptFailed) }
+        guard clientSocketDescriptor > -1 else {
+            addr.deallocateCapacity(1)
+            throw Error(.acceptFailed)
+        }
         let clientAddress = ResolvedInternetAddress(raw: addr)
         let clientSocket = try TCPInternetSocket(descriptor: clientSocketDescriptor,
                                                  config: config,

--- a/Sources/SocksCore/Types.swift
+++ b/Sources/SocksCore/Types.swift
@@ -44,16 +44,7 @@ public enum AddressFamily {
 }
 
 public typealias Descriptor = Int32
-
-//
-//  A Port can be specified as an integer or
-//  as a service: e.g. you can assign a 
-//  Port to "echo" or to the number 7
-//
-public enum Port {
-    case serviceName(String)
-    case portNumber(UInt16)
-}
+public typealias Port = UInt16
 
 //Extensions
 
@@ -71,12 +62,7 @@ protocol CTypeUnsafePointerOfInt8TypeConvertible {
 
 extension Port: StringConvertable {
     func toString() -> String {
-        switch self {
-        case .serviceName(let service):
-            return service
-        case .portNumber(let portNumber):
-            return String(portNumber)
-        }
+        return String(self)
     }
 }
 

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -58,7 +58,10 @@ public class UDPInternetSocket: InternetSocket {
             addrSockAddr,
             &length
         )
-        guard receivedBytes > -1 else { throw Error(.readFailed) }
+        guard receivedBytes > -1 else {
+            addr.deallocateCapacity(1)
+            throw Error(.readFailed)
+        }
         
         let clientAddress = ResolvedInternetAddress(raw: addr)
         

--- a/Sources/SocksCoreExampleTCPClient/main.swift
+++ b/Sources/SocksCoreExampleTCPClient/main.swift
@@ -1,10 +1,10 @@
 
 import SocksCore
 
-let address = InternetAddress(hostname: "google.com", port: .portNumber(80))
+let address = InternetAddress(hostname: "google.com", port: 80)
 // let address = InternetAddress.localhost(port: 8080)
 //let address = InternetAddress.localhost(port: 8080, ipVersion: .inet6)
-//let address = InternetAddress(hostname: "216.58.214.206", port: .portNumber(80))
+//let address = InternetAddress(hostname: "216.58.214.206", port: 80)
 
 do {
     let socket = try TCPInternetSocket(address: address)

--- a/Sources/SocksExampleTCPClient/main.swift
+++ b/Sources/SocksExampleTCPClient/main.swift
@@ -1,10 +1,10 @@
 
 import Socks
 
-let address = InternetAddress(hostname: "google.com", port: .portNumber(80))
-//let address = InternetAddress(hostname: "216.58.208.46", port: .portNumber(80))
+let address = InternetAddress(hostname: "google.com", port: 80)
+//let address = InternetAddress(hostname: "216.58.208.46", port: 80)
 // let address = InternetAddress.localhost(port: 8080)
-//let address = InternetAddress(hostname: "192.168.1.170", port: .portNumber(2425))
+//let address = InternetAddress(hostname: "192.168.1.170", port: 2425)
 
 do {
     let client = try TCPClient(address: address)

--- a/Tests/SocksCore/AddressResolutionTests.swift
+++ b/Tests/SocksCore/AddressResolutionTests.swift
@@ -20,7 +20,7 @@ class AddressResolutionTests: XCTestCase {
             let resolver = Resolver(config: .TCP())
             let family: AddressFamily = i < 500 ? .inet : .inet6
             let address = InternetAddress(hostname: "google.com",
-                                          port: .portNumber(80),
+                                          port: 80,
                                           addressFamily: family)
             _ = try resolver.resolve(internetAddress: address)
 //            print(resolved.ipString())

--- a/Tests/SocksCore/LiveTests.swift
+++ b/Tests/SocksCore/LiveTests.swift
@@ -14,7 +14,7 @@ class LiveTests: XCTestCase {
     func testLive_HTTP_Get_Google_ipV4() throws {
         
         let addr = InternetAddress(hostname: "google.com",
-                                   port: .portNumber(80))
+                                   port: 80)
         let socket = try TCPInternetSocket(address: addr)
         
         try socket.connect()


### PR DESCRIPTION
- changed port to just be UInt16 instead of an enum
- fixed wrong endianness when parsing port from ResolvedInternetAddress
- fixed potential leaks in cases when ResolvedInternetAddress was getting created
- added local and remote address getters on sockets
- added a way to wait on a socket to become readable with a timeout
