### PR TITLE
Refactored Resolver

### DIFF
--- a/Sources/SocksCore/Address.swift
+++ b/Sources/SocksCore/Address.swift
@@ -70,8 +70,8 @@ public struct InternetAddress {
 
 extension InternetAddress {
     
-    func resolve(with config: SocketConfig) throws -> ResolvedInternetAddress {
-        return try Resolver(config: config).resolve(internetAddress: self)
+    func resolve(with config: inout SocketConfig) throws -> ResolvedInternetAddress {
+        return try Resolver().resolve(self, with: &config)
     }
 }
 

--- a/Sources/SocksCore/Socket.swift
+++ b/Sources/SocksCore/Socket.swift
@@ -68,11 +68,7 @@ public struct SocketConfig {
         self.socketType = socketType
         self.protocolType = protocolType
     }
-    
-    mutating func adjust(for resolvedAddress: ResolvedInternetAddress) throws {
-        self.addressFamily = try resolvedAddress.addressFamily()
-    }
-    
+        
     public static func TCP(addressFamily: AddressFamily = .unspecified) -> SocketConfig {
         return self.init(addressFamily: addressFamily, socketType: .stream, protocolType: .TCP)
     }

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -92,8 +92,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     
     public convenience init(address: InternetAddress) throws {
         var conf: SocketConfig = .TCP(addressFamily: address.addressFamily)
-        let resolved = try address.resolve(with: conf)
-        try conf.adjust(for: resolved)
+        let resolved = try address.resolve(with: &conf)
         try self.init(descriptor: nil, config: conf, address: resolved)
     }
     

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -37,8 +37,7 @@ public class UDPInternetSocket: InternetSocket {
     
     public convenience init(address: InternetAddress) throws {
         var conf: SocketConfig = .UDP(addressFamily: address.addressFamily)
-        let resolved = try address.resolve(with: conf)
-        try conf.adjust(for: resolved)
+        let resolved = try address.resolve(with: &conf)
         try self.init(descriptor: nil, config: conf, address: resolved)
     }
     

--- a/Tests/SocksCore/AddressResolutionTests.swift
+++ b/Tests/SocksCore/AddressResolutionTests.swift
@@ -17,12 +17,13 @@ class AddressResolutionTests: XCTestCase {
         //https://github.com/czechboy0/Socks/issues/33
         let count = 1000
         for i in 1..<count {
-            let resolver = Resolver(config: .TCP())
+            let resolver = Resolver()
             let family: AddressFamily = i < 500 ? .inet : .inet6
             let address = InternetAddress(hostname: "google.com",
                                           port: 80,
                                           addressFamily: family)
-            _ = try resolver.resolve(internetAddress: address)
+            var config: SocketConfig = .TCP()
+            _ = try resolver.resolve(address, with: &config)
 //            print(resolved.ipString())
         }
     }


### PR DESCRIPTION
Refactored Resolver to make it impossible to forget to adjust the SocketConfig for the resolved AddressFamily

Addresses this concern brought up by @MatthiasKreileder: https://github.com/czechboy0/Socks/pull/44/files/ce1c852cc3b10ae8c38c53ed2e13bf232fbfc8d2#r66617229
