### PR TITLE
Don't fail accept() when EINTR is sent

### DIFF
--- a/Sources/SocksCore/Error.swift
+++ b/Sources/SocksCore/Error.swift
@@ -81,6 +81,8 @@ public struct ErrorLookUpTable {
         return description
     }
     
+    public static let interruptedSystemCall: Int32 = EINTR
+    
     static let errorDescriptions = [
         0: "Success",
         1: "Operation not permitted",

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -149,6 +149,9 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
         let clientSocketDescriptor = socket_accept(self.descriptor, addrSockAddr, &length)
         guard clientSocketDescriptor > -1 else {
             addr.deallocate(capacity: 1)
+            if errno == ErrorLookUpTable.interruptedSystemCall {
+                return try accept()
+            }
             throw SocksError(.acceptFailed)
         }
         let clientAddress = ResolvedInternetAddress(raw: addr)


### PR DESCRIPTION
Fixes the annoying log `Server error: accept(Socket failed with code 4 ("Interrupted system call") [acceptFailed] "Non-recoverable failure in name resolution")` when a breakpoint is manipulated in Xcode while the server is running.

/cc @LoganWright @tannernelson 
