### PR TITLE
Linux-arm uses different structure for FDSet

### DIFF
--- a/Sources/SocksCore/FDSet.swift
+++ b/Sources/SocksCore/FDSet.swift
@@ -31,7 +31,11 @@ import Darwin
 
 func fdZero(_ set: inout fd_set) {
 #if os(Linux)
+#if arch(arm)
+  set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#else
   set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+#endif
 #else
   set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 #endif


### PR DESCRIPTION
This code simply breaks out the case of linux-arm in the zero-setting of
FDSet.
