### PR TITLE
Fixes for a few crashes related to setsockopt() and getsockopt()

### DIFF
--- a/Sources/SocksCore/SocketOptions+Deprecated.swift
+++ b/Sources/SocksCore/SocketOptions+Deprecated.swift
@@ -21,9 +21,10 @@ extension RawSocket {
     /// Returns the current error code of the socket (0 if no error)
     @available(*, deprecated, message: "use getErrorCode() instead")
     public var errorCode: Int32 {
-        return try! Self.getOption(descriptor: descriptor,
-                                   level: SOL_SOCKET,
-                                   name: SO_ERROR)
+        let code:Int32? = try? Self.getOption(descriptor: descriptor,
+                                              level: SOL_SOCKET,
+                                              name: SO_ERROR)
+        return code ?? -1
     }
     
     
@@ -31,15 +32,16 @@ extension RawSocket {
     @available(*, deprecated, message: "use getKeepAlive/setKeepAlive instead")
     public var keepAlive: Bool {
         nonmutating set {
-            try! Self.setBoolOption(descriptor: descriptor,
+            try? Self.setBoolOption(descriptor: descriptor,
                                     level: SOL_SOCKET,
                                     name: SO_KEEPALIVE,
                                     value: newValue)
         }
         get {
-            return try! Self.getBoolOption(descriptor: descriptor,
-                                           level: SOL_SOCKET,
-                                           name: SO_KEEPALIVE)
+            let keepAlive:Bool? = try? Self.getBoolOption(descriptor: descriptor,
+                                                          level: SOL_SOCKET,
+                                                          name: SO_KEEPALIVE)
+            return keepAlive ?? false
         }
     }
     
@@ -47,15 +49,16 @@ extension RawSocket {
     @available(*, deprecated, message: "use getReuseAddress/setReuseAddress instead")
     public var reuseAddress: Bool {
         nonmutating set {
-            try! Self.setBoolOption(descriptor: descriptor,
+            try? Self.setBoolOption(descriptor: descriptor,
                                     level: SOL_SOCKET,
                                     name: SO_REUSEADDR,
                                     value: newValue)
         }
         get {
-            return try! Self.getBoolOption(descriptor: descriptor,
-                                           level: SOL_SOCKET,
-                                           name: SO_REUSEADDR)
+            let reuseAddress:Bool? = try? Self.getBoolOption(descriptor: descriptor,
+                                                             level: SOL_SOCKET,
+                                                             name: SO_REUSEADDR)
+            return reuseAddress ?? false
         }
     }
     
@@ -64,15 +67,16 @@ extension RawSocket {
     @available(*, deprecated, message: "use getReceivingTimeout/setReceivingTimeout instead")
     public var receivingTimeout: timeval {
         nonmutating set {
-            try! Self.setOption(descriptor: descriptor,
+            try? Self.setOption(descriptor: descriptor,
                                 level: SOL_SOCKET,
                                 name: SO_RCVTIMEO,
                                 value: newValue)
         }
         get {
-            return try! Self.getOption(descriptor: descriptor,
-                                       level: SOL_SOCKET,
-                                       name: SO_RCVTIMEO)
+            let receivingTimeout:timeval? = try? Self.getOption(descriptor: descriptor,
+                                                                level: SOL_SOCKET,
+                                                                name: SO_RCVTIMEO)
+            return receivingTimeout ?? timeval(seconds: 0)
         }
     }
     
@@ -81,15 +85,16 @@ extension RawSocket {
     @available(*, deprecated, message: "use getSendingTimeout/setSendingTimeout instead")
     public var sendingTimeout: timeval {
         nonmutating set {
-            try! Self.setOption(descriptor: descriptor,
+            try? Self.setOption(descriptor: descriptor,
                                 level: SOL_SOCKET,
                                 name: SO_SNDTIMEO,
                                 value: newValue)
         }
         get {
-            return try! Self.getOption(descriptor: descriptor,
-                                       level: SOL_SOCKET,
-                                       name: SO_SNDTIMEO)
+            let sendingTimeout:timeval? = try? Self.getOption(descriptor: descriptor,
+                                                              level: SOL_SOCKET,
+                                                              name: SO_SNDTIMEO)
+            return sendingTimeout ?? timeval(seconds: 0)
         }
     }
 }

--- a/Sources/SocksCore/SocketOptions+Deprecated.swift
+++ b/Sources/SocksCore/SocketOptions+Deprecated.swift
@@ -1,0 +1,95 @@
+//
+//  SocketOptions+Deprecated.swift
+//  Socks
+//
+//  Created by Andreas Ley on 20.10.16.
+//
+//
+
+#if os(Linux)
+    import Glibc
+    private let s_socket = Glibc.socket
+    private let s_close = Glibc.close
+#else
+    import Darwin
+    private let s_socket = Darwin.socket
+    private let s_close = Darwin.close
+#endif
+
+extension RawSocket {
+    
+    /// Returns the current error code of the socket (0 if no error)
+    @available(*, deprecated, message: "use getErrorCode() instead")
+    public var errorCode: Int32 {
+        return try! Self.getOption(descriptor: descriptor,
+                                   level: SOL_SOCKET,
+                                   name: SO_ERROR)
+    }
+    
+    
+    /// Keepalive messages enabled (if implemented by protocol)
+    @available(*, deprecated, message: "use getKeepAlive/setKeepAlive instead")
+    public var keepAlive: Bool {
+        nonmutating set {
+            try! Self.setBoolOption(descriptor: descriptor,
+                                    level: SOL_SOCKET,
+                                    name: SO_KEEPALIVE,
+                                    value: newValue)
+        }
+        get {
+            return try! Self.getBoolOption(descriptor: descriptor,
+                                           level: SOL_SOCKET,
+                                           name: SO_KEEPALIVE)
+        }
+    }
+    
+    /// Binding allowed (under certain conditions) to an address or port already in use
+    @available(*, deprecated, message: "use getReuseAddress/setReuseAddress instead")
+    public var reuseAddress: Bool {
+        nonmutating set {
+            try! Self.setBoolOption(descriptor: descriptor,
+                                    level: SOL_SOCKET,
+                                    name: SO_REUSEADDR,
+                                    value: newValue)
+        }
+        get {
+            return try! Self.getBoolOption(descriptor: descriptor,
+                                           level: SOL_SOCKET,
+                                           name: SO_REUSEADDR)
+        }
+    }
+    
+    /// Specify the receiving timeout until reporting an error
+    /// Zero timeval means wait forever
+    @available(*, deprecated, message: "use getReceivingTimeout/setReceivingTimeout instead")
+    public var receivingTimeout: timeval {
+        nonmutating set {
+            try! Self.setOption(descriptor: descriptor,
+                                level: SOL_SOCKET,
+                                name: SO_RCVTIMEO,
+                                value: newValue)
+        }
+        get {
+            return try! Self.getOption(descriptor: descriptor,
+                                       level: SOL_SOCKET,
+                                       name: SO_RCVTIMEO)
+        }
+    }
+    
+    /// Specify the sending timeout until reporting an error
+    /// Zero timeval means wait forever
+    @available(*, deprecated, message: "use getSendingTimeout/setSendingTimeout instead")
+    public var sendingTimeout: timeval {
+        nonmutating set {
+            try! Self.setOption(descriptor: descriptor,
+                                level: SOL_SOCKET,
+                                name: SO_SNDTIMEO,
+                                value: newValue)
+        }
+        get {
+            return try! Self.getOption(descriptor: descriptor,
+                                       level: SOL_SOCKET,
+                                       name: SO_SNDTIMEO)
+        }
+    }
+}

--- a/Sources/SocksCore/SocketOptions.swift
+++ b/Sources/SocksCore/SocketOptions.swift
@@ -36,76 +36,48 @@ extension RawSocket {
         }
     }
     
-    /// Returns the current error code of the socket (0 if no error) 
-    public var errorCode: Int32 {
-        return try! Self.getOption(descriptor: descriptor,
-                                   level: SOL_SOCKET,
-                                   name: SO_ERROR)
+    /// Returns the current error code of the socket (0 if no error)
+    public func getErrorCode() throws -> Int32
+    {
+        return try Self.getOption(descriptor: descriptor,
+                                  level: SOL_SOCKET,
+                                  name: SO_ERROR)
     }
     
-    //When we have throwing property setters, remove the bangs below
-    
     /// Keepalive messages enabled (if implemented by protocol)
-    public var keepAlive: Bool {
-        nonmutating set {
-            try! Self.setBoolOption(descriptor: descriptor,
-                                    level: SOL_SOCKET,
-                                    name: SO_KEEPALIVE,
-                                    value: newValue)
-        }
-        get {
-            return try! Self.getBoolOption(descriptor: descriptor,
-                                           level: SOL_SOCKET,
-                                           name: SO_KEEPALIVE)
-        }
+    public func getKeepAlive() throws -> Bool {
+        return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE)
+    }
+    public func setKeepAlive(_ newValue:Bool) throws {
+        try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE, value: newValue)
     }
     
     /// Binding allowed (under certain conditions) to an address or port already in use
-    public var reuseAddress: Bool {
-        nonmutating set {
-            try! Self.setBoolOption(descriptor: descriptor,
-                                    level: SOL_SOCKET,
-                                    name: SO_REUSEADDR,
-                                    value: newValue)
-        }
-        get {
-            return try! Self.getBoolOption(descriptor: descriptor,
-                                           level: SOL_SOCKET,
-                                           name: SO_REUSEADDR)
-        }
+    public func getReuseAddress() throws -> Bool {
+        return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR)
+    }
+    public func setReuseAddress(_ newValue:Bool) throws {
+        try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR, value: newValue)
     }
     
     /// Specify the receiving timeout until reporting an error
     /// Zero timeval means wait forever
-    public var receivingTimeout: timeval {
-        nonmutating set {
-            try! Self.setOption(descriptor: descriptor,
-                                level: SOL_SOCKET,
-                                name: SO_RCVTIMEO,
-                                value: newValue)
-        }
-        get {
-            return try! Self.getOption(descriptor: descriptor,
-                                       level: SOL_SOCKET,
-                                       name: SO_RCVTIMEO)
-        }
+    public func getReceivingTimeout() throws -> timeval {
+        return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO)
+    }
+    public func setReceivingTimeout(_ newValue:timeval) throws {
+        try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO, value: newValue)
     }
     
     /// Specify the sending timeout until reporting an error
     /// Zero timeval means wait forever
-    public var sendingTimeout: timeval {
-        nonmutating set {
-            try! Self.setOption(descriptor: descriptor,
-                                level: SOL_SOCKET,
-                                name: SO_SNDTIMEO,
-                                value: newValue)
-        }
-        get {
-            return try! Self.getOption(descriptor: descriptor,
-                                       level: SOL_SOCKET,
-                                       name: SO_SNDTIMEO)
-        }
+    public func getSendingTimeout() throws -> timeval {
+        return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO)
     }
+    public func setSendingTimeout(_ newValue:timeval) throws {
+        try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO, value: newValue)
+    }
+    
 }
 
 extension RawSocket {

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -87,7 +87,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
         self.address = address
         self.closed = false
 
-        self.reuseAddress = true
+        try setReuseAddress(true)
     }
 
     public convenience init(address: InternetAddress) throws {
@@ -131,7 +131,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
         }
 
         //ensure no error was encountered
-        let err = self.errorCode
+        let err = try self.getErrorCode()
         guard err == 0 else {
             throw SocksError(.connectFailedWithSocketErrorCode(err))
         }

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -32,7 +32,7 @@ public class UDPInternetSocket: InternetSocket {
         self.config = config
         self.address = address
 
-        self.reuseAddress = true
+        try setReuseAddress(true)
     }
 
     public convenience init(address: InternetAddress) throws {

--- a/Tests/SocksCoreTests/OptionsTests.swift
+++ b/Tests/SocksCoreTests/OptionsTests.swift
@@ -6,6 +6,16 @@
 //
 //
 
+#if os(Linux)
+    import Glibc
+    private let s_socket = Glibc.socket
+    private let s_close = Glibc.close
+#else
+    import Darwin
+    private let s_socket = Darwin.socket
+    private let s_close = Darwin.close
+#endif
+
 import XCTest
 @testable import SocksCore
 

--- a/Tests/SocksCoreTests/OptionsTests.swift
+++ b/Tests/SocksCoreTests/OptionsTests.swift
@@ -1,0 +1,53 @@
+//
+//  OptionsTests.swift
+//  Socks
+//
+//  Created by Andreas Ley on 20.10.16.
+//
+//
+
+import XCTest
+@testable import SocksCore
+
+class OptionsTests: XCTestCase {
+    
+    func testSocketOptions() throws {
+        let (read, _) = try TCPEstablishedSocket.pipe()
+        
+        try read.setReuseAddress(true)
+        let reuseAddress = try read.getReuseAddress()
+        XCTAssert(reuseAddress == true)
+        
+        try read.setKeepAlive(true)
+        let keepAlive = try read.getKeepAlive()
+        XCTAssert(keepAlive == true)
+        
+        let expectedTimeout = timeval(seconds: 0.987)
+        
+        try read.setSendingTimeout(expectedTimeout)
+        let sendingTimeout = try read.getSendingTimeout()
+        XCTAssert(sendingTimeout == expectedTimeout)
+        
+        try read.setReceivingTimeout(expectedTimeout)
+        let receivingTimeout = try read.getReceivingTimeout()
+        XCTAssert(receivingTimeout == expectedTimeout)
+    }
+    
+    func testReadingSocketOptionOnClosedSocket() throws {
+        let (read, _) = try TCPEstablishedSocket.pipe()
+        try read.close()
+        do {
+            _ = try read.getSendingTimeout()
+        }
+        catch let error as SocksError {
+            guard case ErrorReason.optionGetFailed(level: SOL_SOCKET, name: SO_SNDTIMEO, type: "timeval") = error.type else {
+                XCTFail()
+                return
+            }
+        }
+        catch {
+            XCTFail("Wrong error")
+        }
+        
+    }
+}

--- a/Tests/SocksCoreTests/TimeoutTests.swift
+++ b/Tests/SocksCoreTests/TimeoutTests.swift
@@ -21,15 +21,15 @@ class TimeoutTests: XCTestCase {
     
     func testDefaults() throws {
         let (read, write) = try TCPEstablishedSocket.pipe()
-        XCTAssertEqual(read.receivingTimeout, timeval(seconds: 0))
-        XCTAssertEqual(write.sendingTimeout, timeval(seconds: 0))
+        XCTAssertEqual(try read.getReceivingTimeout(), timeval(seconds: 0))
+        XCTAssertEqual(try write.getSendingTimeout(), timeval(seconds: 0))
     }
-    
+
     func testReceiveTimeoutTiny() throws {
         let (read, write) = try TCPEstablishedSocket.pipe()
         defer { try! read.close(); try! write.close() }
-        read.receivingTimeout = timeval(seconds: 0.5)
-        XCTAssertEqual(read.receivingTimeout, timeval(seconds: 0.5))
+        try read.setReceivingTimeout(timeval(seconds: 0.5))
+        XCTAssertEqual(try read.getReceivingTimeout(), timeval(seconds: 0.5))
         let duration = time {
             do {
                 _ = try read.recv()
@@ -52,8 +52,8 @@ class TimeoutTests: XCTestCase {
     func testReceiveTimeoutSmall() throws {
         let (read, write) = try TCPEstablishedSocket.pipe()
         defer { try! read.close(); try! write.close() }
-        read.receivingTimeout = timeval(seconds: 1)
-        XCTAssertEqual(read.receivingTimeout, timeval(seconds: 1))
+        try read.setReceivingTimeout(timeval(seconds: 1))
+        XCTAssertEqual(try read.getReceivingTimeout(), timeval(seconds: 1))
         let duration = time {
             do {
                 _ = try read.recv()
@@ -76,8 +76,8 @@ class TimeoutTests: XCTestCase {
     func testSendTimeoutSmall() throws {
         let (read, write) = try TCPEstablishedSocket.pipe()
         defer { try! read.close(); try! write.close() }
-        write.sendingTimeout = timeval(seconds: 1)
-        XCTAssertEqual(write.sendingTimeout, timeval(seconds: 1))
+        try write.setSendingTimeout(timeval(seconds: 1))
+        XCTAssertEqual(try write.getSendingTimeout(), timeval(seconds: 1))
 
         // HELP: how can we test a hanging send?
     }
@@ -118,5 +118,4 @@ class TimeoutTests: XCTestCase {
         }
         XCTAssertEqualWithAccuracy(duration, 1.0, accuracy: 0.1)
     }
-
 }


### PR DESCRIPTION
In certain circumstances, `setsockopt()` and `getsockopt()` can fail (e.g. when the socket is already closed). The current version correctly detects that, but the properties for the options would force-try anyway and end up with a crash. This PR deprecates the properties in favor of throwing funcs.