### PR TITLE
Various improvements

### DIFF
--- a/Sources/SocksCore/Error.swift
+++ b/Sources/SocksCore/Error.swift
@@ -42,6 +42,8 @@ public enum ErrorReason {
     case unsupportedSocketAddressFamily(Int32)
     case concreteSocketAddressFamilyRequired
     
+    case socketIsClosed
+    
     case generic(String)
 }
 

--- a/Sources/SocksCore/Socket.swift
+++ b/Sources/SocksCore/Socket.swift
@@ -18,6 +18,7 @@
 
 public protocol RawSocket {
     var descriptor: Descriptor { get }
+    var closed:Bool { get }
     func close() throws
 }
 

--- a/Sources/SocksCore/SocketOptions.swift
+++ b/Sources/SocksCore/SocketOptions.swift
@@ -21,10 +21,12 @@ extension RawSocket {
     /// Control whether the socket calls are blocking or nonblocking
     public var blocking: Bool {
         get {
+            if closed { return true }
             let flags = fcntl(descriptor, F_GETFL, 0)
             return flags & O_NONBLOCK == 0
         }
         nonmutating set {
+            if closed { return }
             let flags = fcntl(descriptor, F_GETFL, 0)
             let newFlags: Int32
             if newValue {
@@ -39,6 +41,7 @@ extension RawSocket {
     /// Returns the current error code of the socket (0 if no error)
     public func getErrorCode() throws -> Int32
     {
+        if closed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor,
                                   level: SOL_SOCKET,
                                   name: SO_ERROR)
@@ -46,35 +49,43 @@ extension RawSocket {
     
     /// Keepalive messages enabled (if implemented by protocol)
     public func getKeepAlive() throws -> Bool {
+        if closed { throw SocksError(.socketIsClosed) }
         return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE)
     }
     public func setKeepAlive(_ newValue:Bool) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE, value: newValue)
     }
     
     /// Binding allowed (under certain conditions) to an address or port already in use
     public func getReuseAddress() throws -> Bool {
+        if closed { throw SocksError(.socketIsClosed) }
         return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR)
     }
     public func setReuseAddress(_ newValue:Bool) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR, value: newValue)
     }
     
     /// Specify the receiving timeout until reporting an error
     /// Zero timeval means wait forever
     public func getReceivingTimeout() throws -> timeval {
+        if closed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO)
     }
     public func setReceivingTimeout(_ newValue:timeval) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO, value: newValue)
     }
     
     /// Specify the sending timeout until reporting an error
     /// Zero timeval means wait forever
     public func getSendingTimeout() throws -> timeval {
+        if closed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO)
     }
     public func setSendingTimeout(_ newValue:timeval) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO, value: newValue)
     }
     

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -44,7 +44,7 @@ extension TCPReadableSocket {
         let receivedBytes = socket_recv(self.descriptor, data.rawBytes, data.capacity, flags)
         guard receivedBytes > -1 else { throw SocksError(.readFailed) }
         let finalBytes = data.characters[0..<receivedBytes]
-        let out = Array(finalBytes.map({ UInt8($0) }))
+        let out = Array(finalBytes)
         return out
     }
 

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -106,11 +106,13 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func connect() throws {
+        if closed { throw SocksError(.socketIsClosed) }
         let res = socket_connect(self.descriptor, address.raw, address.rawLen)
         guard res > -1 else { throw SocksError(.connectFailed) }
     }
 
     public func connect(withTimeout timeout: Double?) throws {
+        if closed { throw SocksError(.socketIsClosed) }
 
         guard let to = timeout else {
             try connect()
@@ -147,11 +149,13 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func listen(queueLimit: Int32 = 4096) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         let res = socket_listen(self.descriptor, queueLimit)
         guard res > -1 else { throw SocksError(.listenFailed) }
     }
 
     public func accept() throws -> TCPInternetSocket {
+        if closed { throw SocksError(.socketIsClosed) }
         var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
         let addr = UnsafeMutablePointer<sockaddr_storage>.allocate(capacity: 1)
         let addrSockAddr = UnsafeMutablePointer<sockaddr>(OpaquePointer(addr))
@@ -212,6 +216,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
 
 public class TCPEstablishedSocket: TCPSocket {
 
+    public let closed = false
     public let descriptor: Descriptor
 
     public init(descriptor: Descriptor) {

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -94,6 +94,10 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
 
         try setReuseAddress(true)
     }
+    
+    deinit {
+        try? self.close()
+    }
 
     public convenience init(address: InternetAddress) throws {
         var conf: SocketConfig = .TCP(addressFamily: address.addressFamily)

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -167,6 +167,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func close() throws {
+        if closed { return }
         stopWatching()
         closed = true
         if socket_close(self.descriptor) != 0 {

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -65,7 +65,7 @@ public class UDPInternetSocket: InternetSocket {
         let clientAddress = ResolvedInternetAddress(raw: addr)
 
         let finalBytes = data.characters[0..<receivedBytes]
-        let out = Array(finalBytes.map({ UInt8($0) }))
+        let out = Array(finalBytes)
         return (data: out, sender: clientAddress)
     }
 

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -10,10 +10,12 @@
     import Glibc
     private let socket_recvfrom = Glibc.recvfrom
     private let socket_sendto = Glibc.sendto
+    private let socket_close = Glibc.close
 #else
     import Darwin
     private let socket_recvfrom = Darwin.recvfrom
     private let socket_sendto = Darwin.sendto
+    private let socket_close = Darwin.close
 #endif
 
 public class UDPInternetSocket: InternetSocket {
@@ -21,6 +23,7 @@ public class UDPInternetSocket: InternetSocket {
     public let descriptor: Descriptor
     public let config: SocketConfig
     public let address: ResolvedInternetAddress
+    public private(set) var closed = false
 
     public required init(descriptor: Descriptor?, config: SocketConfig, address: ResolvedInternetAddress) throws {
 
@@ -39,6 +42,10 @@ public class UDPInternetSocket: InternetSocket {
         var conf: SocketConfig = .UDP(addressFamily: address.addressFamily)
         let resolved = try address.resolve(with: &conf)
         try self.init(descriptor: nil, config: conf, address: resolved)
+    }
+
+    deinit {
+        try? self.close()
     }
 
     public func recvfrom(maxBytes: Int = BufferCapacity) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
@@ -83,5 +90,13 @@ public class UDPInternetSocket: InternetSocket {
             destination.rawLen
         )
         guard sentLen == len else { throw SocksError(.sendFailedToSendAllBytes) }
+    }
+
+    public func close() throws {
+        if closed { return }
+        closed = true
+        if socket_close(self.descriptor) != 0 {
+            throw SocksError(.closeSocketFailed)
+        }
     }
 }

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -49,6 +49,7 @@ public class UDPInternetSocket: InternetSocket {
     }
 
     public func recvfrom(maxBytes: Int = BufferCapacity) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
+        if closed { throw SocksError(.socketIsClosed) }
         let data = Bytes(capacity: maxBytes)
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
 
@@ -77,6 +78,7 @@ public class UDPInternetSocket: InternetSocket {
     }
 
     public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil) throws {
+        if closed { throw SocksError(.socketIsClosed) }
         let len = data.count
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
         let destination = address ?? self.address

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,5 +8,6 @@ XCTMain([
 	testCase(PipeTests.allTests),
 	testCase(SelectTests.allTests),
 	testCase(TimeoutTests.allTests),
-    testCase(WatchingTests.allTests)
+	testCase(WatchingTests.allTests),
+    testCase(LifetimeTests.allTests)
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,5 +7,6 @@ XCTMain([
 	testCase(LiveTests.allTests),
 	testCase(PipeTests.allTests),
 	testCase(SelectTests.allTests),
-	testCase(TimeoutTests.allTests)
+	testCase(TimeoutTests.allTests),
+    testCase(WatchingTests.allTests)
 ])

--- a/Tests/SocksCoreTests/LifetimeTests.swift
+++ b/Tests/SocksCoreTests/LifetimeTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import SocksCore
 
+#if os(Linux)
+    import Glibc
+    private let F_GETFD = Glibc.F_GETFD
+#endif
+
+
 class LifetimeTests: XCTestCase {
     
     func testStoppingTCPInternetSocket() throws {

--- a/Tests/SocksCoreTests/LifetimeTests.swift
+++ b/Tests/SocksCoreTests/LifetimeTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import SocksCore
+
+class LifetimeTests: XCTestCase {
+    
+    func testStoppingTCPInternetSocket() throws {
+        let socket = try TCPInternetSocket(address: .localhost(port: 0))
+
+        // file descriptor should be open
+        let fdFlagOpen = fcntl(socket.descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagOpen, 0)
+        
+        try socket.close()
+        
+        // file descriptor should be closed
+        let fdFlagClosed = fcntl(socket.descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagClosed, -1)
+        
+        // attempt to close a second again; shouldn't throw
+        try socket.close()
+    }
+
+    func testStoppingUDPSocket() throws {
+        let socket = try UDPInternetSocket(address: .localhost(port: 0))
+        
+        // file descriptor should be open
+        let fdFlagOpen = fcntl(socket.descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagOpen, 0)
+        
+        try socket.close()
+        
+        // file descriptor should be closed
+        let fdFlagClosed = fcntl(socket.descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagClosed, -1)
+        
+        // attempt to close a second again; shouldn't throw
+        try socket.close()
+    }
+
+    func testReleasingTCPInternetSocket() throws {
+        var optionalSocket:TCPInternetSocket? = try TCPInternetSocket(address: .localhost(port: 0))
+        
+        guard let descriptor = optionalSocket?.descriptor else {
+            XCTFail("Failed to get descriptor")
+            return
+        }
+        
+        if let socket = optionalSocket {
+            // file descriptor should be open
+            let fdFlagOpen = fcntl(socket.descriptor, F_GETFD)
+            XCTAssertEqual(fdFlagOpen, 0)
+        } else {
+            XCTFail("Failed to create socket")
+        }
+        
+        // release socket
+        optionalSocket = nil
+        
+        // file descriptor should be closed
+        let fdFlagClosed = fcntl(descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagClosed, -1)
+    }
+    
+    func testReleasingUDPInternetSocket() throws {
+        var optionalSocket:UDPInternetSocket? = try UDPInternetSocket(address: .localhost(port: 0))
+        
+        guard let descriptor = optionalSocket?.descriptor else {
+            XCTFail("Failed to get descriptor")
+            return
+        }
+
+        if let socket = optionalSocket {
+            // file descriptor should be open
+            let fdFlagOpen = fcntl(socket.descriptor, F_GETFD)
+            XCTAssertEqual(fdFlagOpen, 0)
+        } else {
+            XCTFail("Failed to create socket")
+        }
+        
+        // release socket
+        optionalSocket = nil
+        
+        // file descriptor should be closed
+        let fdFlagClosed = fcntl(descriptor, F_GETFD)
+        XCTAssertEqual(fdFlagClosed, -1)
+    }
+}

--- a/Tests/SocksCoreTests/LifetimeTests.swift
+++ b/Tests/SocksCoreTests/LifetimeTests.swift
@@ -18,6 +18,20 @@ class LifetimeTests: XCTestCase {
         
         // attempt to close a second again; shouldn't throw
         try socket.close()
+
+        do {
+            // attempt to listen should fail on a closed socket
+            _ = try socket.listen()
+        }
+        catch let error as SocksError {
+            guard case ErrorReason.socketIsClosed = error.type else {
+                XCTFail("Wrong error")
+                return
+            }
+        }
+        catch {
+            XCTFail("Wrong error")
+        }
     }
 
     func testStoppingUDPSocket() throws {
@@ -35,6 +49,20 @@ class LifetimeTests: XCTestCase {
         
         // attempt to close a second again; shouldn't throw
         try socket.close()
+        
+        do {
+            // attempt to receive should fail on a closed socket
+            _ = try socket.recvfrom()
+        }
+        catch let error as SocksError {
+            guard case ErrorReason.socketIsClosed = error.type else {
+                XCTFail("Wrong error")
+                return
+            }
+        }
+        catch {
+            XCTFail("Wrong error")
+        }
     }
 
     func testReleasingTCPInternetSocket() throws {

--- a/Tests/SocksCoreTests/OptionsTests.swift
+++ b/Tests/SocksCoreTests/OptionsTests.swift
@@ -22,32 +22,35 @@ import XCTest
 class OptionsTests: XCTestCase {
     
     func testSocketOptions() throws {
-        let (read, _) = try TCPEstablishedSocket.pipe()
+        let address = InternetAddress(hostname: "0.0.0.0", port: 0)
+        let socket = try TCPInternetSocket(address: address)
         
-        try read.setReuseAddress(true)
-        let reuseAddress = try read.getReuseAddress()
+        try socket.setReuseAddress(true)
+        let reuseAddress = try socket.getReuseAddress()
         XCTAssert(reuseAddress == true)
         
-        try read.setKeepAlive(true)
-        let keepAlive = try read.getKeepAlive()
+        try socket.setKeepAlive(true)
+        let keepAlive = try socket.getKeepAlive()
         XCTAssertEqual(keepAlive, true)
         
         let expectedTimeout = timeval(seconds: 0.987)
         
-        try read.setSendingTimeout(expectedTimeout)
-        let sendingTimeout = try read.getSendingTimeout()
+        try socket.setSendingTimeout(expectedTimeout)
+        let sendingTimeout = try socket.getSendingTimeout()
         XCTAssertEqual(sendingTimeout, expectedTimeout)
         
-        try read.setReceivingTimeout(expectedTimeout)
-        let receivingTimeout = try read.getReceivingTimeout()
+        try socket.setReceivingTimeout(expectedTimeout)
+        let receivingTimeout = try socket.getReceivingTimeout()
         XCTAssertEqual(receivingTimeout, expectedTimeout)
     }
     
     func testReadingSocketOptionOnClosedSocket() throws {
-        let (read, _) = try TCPEstablishedSocket.pipe()
-        try read.close()
+        let address = InternetAddress(hostname: "0.0.0.0", port: 0)
+        let socket = try TCPInternetSocket(address: address)
+
+        try socket.close()
         do {
-            _ = try read.getSendingTimeout()
+            _ = try socket.getSendingTimeout()
         }
         catch let error as SocksError {
             guard case ErrorReason.optionGetFailed(level: SOL_SOCKET, name: SO_SNDTIMEO, type: "timeval") = error.type else {

--- a/Tests/SocksCoreTests/OptionsTests.swift
+++ b/Tests/SocksCoreTests/OptionsTests.swift
@@ -22,8 +22,7 @@ import XCTest
 class OptionsTests: XCTestCase {
     
     func testSocketOptions() throws {
-        let address = InternetAddress(hostname: "0.0.0.0", port: 0)
-        let socket = try TCPInternetSocket(address: address)
+        let socket = try TCPInternetSocket(address: .localhost(port: 0))
         
         try socket.setReuseAddress(true)
         let reuseAddress = try socket.getReuseAddress()
@@ -45,8 +44,7 @@ class OptionsTests: XCTestCase {
     }
     
     func testReadingSocketOptionOnClosedSocket() throws {
-        let address = InternetAddress(hostname: "0.0.0.0", port: 0)
-        let socket = try TCPInternetSocket(address: address)
+        let socket = try TCPInternetSocket(address: .localhost(port: 0))
 
         try socket.close()
         do {

--- a/Tests/SocksCoreTests/OptionsTests.swift
+++ b/Tests/SocksCoreTests/OptionsTests.swift
@@ -53,7 +53,7 @@ class OptionsTests: XCTestCase {
             _ = try socket.getSendingTimeout()
         }
         catch let error as SocksError {
-            guard case ErrorReason.optionGetFailed(level: SOL_SOCKET, name: SO_SNDTIMEO, type: "timeval") = error.type else {
+            guard case ErrorReason.socketIsClosed = error.type else {
                 XCTFail()
                 return
             }

--- a/Tests/SocksCoreTests/WatchingTests.swift
+++ b/Tests/SocksCoreTests/WatchingTests.swift
@@ -4,6 +4,14 @@ import Dispatch
 
 class WatchingTests: XCTestCase {
     
+    func testWatching1000Times() throws {
+        // this test needs to run a few times to make sure that GCD semaphores (used in `DispatchSource`) are properly released
+        for index in 0..<1000 {
+            print("Test \(index)")
+            try testWatching()
+        }
+    }
+
     func testWatching() throws {
         
         let serverAddress = InternetAddress.localhost(port: 0)

--- a/Tests/SocksCoreTests/WatchingTests.swift
+++ b/Tests/SocksCoreTests/WatchingTests.swift
@@ -4,42 +4,77 @@ import Dispatch
 
 class WatchingTests: XCTestCase {
     
-    func testWatching1000Times() throws {
-        // this test needs to run a few times to make sure that GCD semaphores (used in `DispatchSource`) are properly released
-        for index in 0..<1000 {
-            print("Test \(index)")
-            try testWatching()
-        }
-    }
-
     func testWatching() throws {
         
+        let testData:[UInt8] = [1,2,3]
+        
         let serverAddress = InternetAddress.localhost(port: 0)
-        let serverSocket = try TCPInternetSocket(address: serverAddress)
-        try serverSocket.bind()
-        try serverSocket.listen(queueLimit: 4096)
-        
-        let queue = DispatchQueue(label: "codes.vapor.watchingTest", qos: .background)
-        let group = DispatchGroup()
-        
-        group.enter()
-        try serverSocket.startWatching(on: queue) {
-            group.leave()
-        }
-        
-        let automaticallyAssignedServerAddress = try serverSocket.localAddress()
-        let connectToAddress = InternetAddress.localhost(port: automaticallyAssignedServerAddress.port)
+        var serverSocket:TCPInternetSocket? = try TCPInternetSocket(address: serverAddress)
+        if let socket = serverSocket {
+            try socket.bind()
+            try socket.listen(queueLimit: 4096)
+            
+            let queue = DispatchQueue(label: "codes.vapor.watchingTest", qos: .background)
+            let group = DispatchGroup()
+            
+            try socket.startWatching(on: queue) {
+                guard let clientSocket = try? socket.accept() else {
+                    XCTFail("Socket failed to accept")
+                    return
+                }
+                
+                do {
+                    try clientSocket.startWatching(on: queue) {
+                        do {
+                            let data = try clientSocket.recv(maxBytes: 65_507)
+                            // ignore all socket events except those with data
+                            guard data.count > 0 else { return }
+                            if data == testData {
+                                group.leave()
+                            }
+                        } catch {
+                            XCTFail("Client socket failed to receive data")
+                        }
+                    }
+                } catch {
+                    XCTFail("Client socket failed to start watching")
+                }
+            }
+            
+            let automaticallyAssignedServerAddress = try socket.localAddress()
+//            print("Hosting on port \(automaticallyAssignedServerAddress.port); descriptor \(socket.descriptor)")
+            let serverAddress = InternetAddress.localhost(port: automaticallyAssignedServerAddress.port)
+            
+            // first attempt; this should trigger a group leave
+            let result = try connectToServer(serverAddress, on: queue, in: group, timeout: 1, send: testData)
+            guard result == DispatchTimeoutResult.success else {
+                XCTFail("Test timed out")
+                return
+            }
 
-        let clientSocket = try TCPInternetSocket(address: connectToAddress)
-        try clientSocket.connect()
-        
-        let timeout:Double = 1
-        let result = group.wait(timeout: .now() + timeout)
-        guard result == DispatchTimeoutResult.success else {
-            XCTFail("Test timed out after \(timeout) seconds")
-            return
+            socket.stopWatching()
+
+            // second attempt; this should time out, because the socket shouldn't be watching anymore
+            let result2 = try connectToServer(serverAddress, on: queue, in: group, timeout: 0.1, send: testData)
+            guard result2 == DispatchTimeoutResult.timedOut else {
+                XCTFail("Test should have timed out")
+                return
+            }
         }
         
-        serverSocket.stopWatching()
+        serverSocket = nil
+    }
+    
+    func connectToServer(_ address:InternetAddress, on queue:DispatchQueue, in group:DispatchGroup, timeout:Double, send data:[UInt8]) throws -> DispatchTimeoutResult
+    {
+        group.enter()
+        let clientSocket = try TCPInternetSocket(address: address)
+        try clientSocket.connect()
+        try clientSocket.send(data: data)
+        
+        let result = group.wait(timeout: .now() + timeout)
+        try clientSocket.close()
+
+        return result
     }
 }

--- a/Tests/SocksCoreTests/XCTestManifests.swift
+++ b/Tests/SocksCoreTests/XCTestManifests.swift
@@ -72,3 +72,14 @@ extension WatchingTests {
         ]
     }
 }
+
+extension LifetimeTests {
+    static var allTests : [(String, (LifetimeTests) -> () throws -> Void)] {
+        return [
+            ("testStoppingTCPInternetSocket", testStoppingTCPInternetSocket),
+            ("testStoppingUDPSocket", testStoppingUDPSocket),
+            ("testReleasingTCPInternetSocket", testReleasingTCPInternetSocket),
+            ("testReleasingUDPInternetSocket", testReleasingUDPInternetSocket)
+        ]
+    }
+}

--- a/Tests/SocksCoreTests/XCTestManifests.swift
+++ b/Tests/SocksCoreTests/XCTestManifests.swift
@@ -64,3 +64,11 @@ extension TimeoutTests {
         ]
     }
 }
+
+extension WatchingTests {
+    static var allTests : [(String, (WatchingTests) -> () throws -> Void)] {
+        return [
+            ("testWatching1000Times", testWatching1000Times)
+        ]
+    }
+}

--- a/Tests/SocksCoreTests/XCTestManifests.swift
+++ b/Tests/SocksCoreTests/XCTestManifests.swift
@@ -68,7 +68,7 @@ extension TimeoutTests {
 extension WatchingTests {
     static var allTests : [(String, (WatchingTests) -> () throws -> Void)] {
         return [
-            ("testWatching1000Times", testWatching1000Times)
+            ("testWatching", testWatching)
         ]
     }
 }


### PR DESCRIPTION
## Improved performance
Previously, all bytes received were passed trough an `map` operation
that is not required, since the bytes are already `UInt8`. This change
improves performance for large transfers considerably.

Improves https://github.com/vapor/vapor/issues/734

## Improved cleanup and safety
- `TCPInternetSocket` and `UDPInternetSocket` now close their descriptors on deinit
- Additional calls to `close()` don't try to close the file descriptor anymore
- Attempts to use a closed `TCPInternetSocket` or `UDPInternetSocket` now throw to prevent using a descriptor that may already be used otherwise

## Improved testing
- `WatchingTests` are now run under Linux, too
- `WatchingTests` should not fail anymore
- Added tests for releasing and using closed sockets