### PR TITLE
Correct documentation on method signature of `startWatching`

### DIFF
--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -205,7 +205,6 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     /**
         Start watching the socket for available data and execute the `handler`
         on the specified queue if data is ready to be received.
-        If a `cancel` handler was passed, it will be run when watching stops (e.g. if the socket is closed).
         Watching sets the socket to nonblocking.
     */
     public func startWatching(on queue: DispatchQueue, handler: @escaping () -> ()) throws {


### PR DESCRIPTION
It's leftover from #100