### PR TITLE
Fix Linux socket read code and handle remote closes

### DIFF
--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -44,7 +44,7 @@ extension TCPReadableSocket {
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
         let receivedBytes = socket_recv(self.descriptor, data.rawBytes, data.capacity, flags)
         guard receivedBytes > -1 else {
-	    if errno == 104 { // closed by peer, need to close this side too!
+	    if errno == ECONNRESET { // closed by peer, need to close this side too!
 	       _ = try? self.close()
 	       return [] 
 	    } else {

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -47,7 +47,7 @@ extension TCPReadableSocket {
                 // closed by peer, need to close this side. 
                 // Since this is not an error, no need to throw unless the close
                 // itself throws an error.
-                _ = try? self.close()
+                _ = try self.close()
                 return []
             } else {
                 throw SocksError(.readFailed)

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -43,7 +43,10 @@ extension TCPReadableSocket {
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
         let receivedBytes = socket_recv(self.descriptor, data.rawBytes, data.capacity, flags)
         guard receivedBytes != -1 else {
-            if errno == ECONNRESET { // closed by peer, need to close this side too!
+            if errno == ECONNRESET {
+                // closed by peer, need to close this side. 
+                // Since this is not an error, no need to throw unless the close
+                // itself throws an error.
                 _ = try? self.close()
                 return []
             } else {


### PR DESCRIPTION
Under load (wrk -t2 -c5 -d5s http://localhost:8080/) the socket occasionally gets closed by the remote end and the server throws an error instead of closing the socket.

This PR fixes this.