### PR TITLE
rename closed to isClosed

### DIFF
--- a/Sources/SocksCore/Socket.swift
+++ b/Sources/SocksCore/Socket.swift
@@ -18,7 +18,7 @@
 
 public protocol RawSocket {
     var descriptor: Descriptor { get }
-    var closed: Bool { get }
+    var isClosed: Bool { get }
     func close() throws
 }
 
@@ -31,6 +31,11 @@ extension RawSocket {
         if s_close(self.descriptor) != 0 {
             throw SocksError(.closeSocketFailed)
         }
+    }
+
+    @available(*, deprecated: 1.2.6, renamed: "isClosed", message: "use isClosed instead")
+    public var closed: Bool {
+        return isClosed
     }
 }
 

--- a/Sources/SocksCore/SocketOptions.swift
+++ b/Sources/SocksCore/SocketOptions.swift
@@ -21,12 +21,12 @@ extension RawSocket {
     /// Control whether the socket calls are blocking or nonblocking
     public var blocking: Bool {
         get {
-            if closed { return true }
+            if isClosed { return true }
             let flags = fcntl(descriptor, F_GETFL, 0)
             return flags & O_NONBLOCK == 0
         }
         nonmutating set {
-            if closed { return }
+            if isClosed { return }
             let flags = fcntl(descriptor, F_GETFL, 0)
             let newFlags: Int32
             if newValue {
@@ -41,7 +41,7 @@ extension RawSocket {
     /// Returns the current error code of the socket (0 if no error)
     public func getErrorCode() throws -> Int32
     {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor,
                                   level: SOL_SOCKET,
                                   name: SO_ERROR)
@@ -49,43 +49,43 @@ extension RawSocket {
     
     /// Keepalive messages enabled (if implemented by protocol)
     public func getKeepAlive() throws -> Bool {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE)
     }
     public func setKeepAlive(_ newValue:Bool) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_KEEPALIVE, value: newValue)
     }
     
     /// Binding allowed (under certain conditions) to an address or port already in use
     public func getReuseAddress() throws -> Bool {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         return try Self.getBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR)
     }
     public func setReuseAddress(_ newValue:Bool) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         try Self.setBoolOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_REUSEADDR, value: newValue)
     }
     
     /// Specify the receiving timeout until reporting an error
     /// Zero timeval means wait forever
     public func getReceivingTimeout() throws -> timeval {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO)
     }
     public func setReceivingTimeout(_ newValue:timeval) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_RCVTIMEO, value: newValue)
     }
     
     /// Specify the sending timeout until reporting an error
     /// Zero timeval means wait forever
     public func getSendingTimeout() throws -> timeval {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         return try Self.getOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO)
     }
     public func setSendingTimeout(_ newValue:timeval) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         try Self.setOption(descriptor: descriptor, level: SOL_SOCKET, name: SO_SNDTIMEO, value: newValue)
     }
     

--- a/Sources/SocksCore/TCPSocket.swift
+++ b/Sources/SocksCore/TCPSocket.swift
@@ -44,7 +44,7 @@ extension TCPReadableSocket {
         let receivedBytes = socket_recv(self.descriptor, data.rawBytes, data.capacity, flags)
         guard receivedBytes != -1 else {
             if errno == ECONNRESET {
-                // closed by peer, need to close this side. 
+                // closed by peer, need to close this side.
                 // Since this is not an error, no need to throw unless the close
                 // itself throws an error.
                 _ = try self.close()
@@ -57,7 +57,7 @@ extension TCPReadableSocket {
         guard receivedBytes > 0 else {
             // receiving 0 indicates a proper close .. no error.
             // attempt a close, no failure possible because throw indicates already closed
-            // if already closed, no issue. 
+            // if already closed, no issue.
             // do NOT propogate as error
             _ = try? self.close()
             return []
@@ -96,7 +96,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     public private(set) var descriptor: Descriptor
     public let config: SocketConfig
     public let address: ResolvedInternetAddress
-    public private(set) var closed: Bool
+    public private(set) var isClosed: Bool
     private var sendingBuffer = [UInt8]()
     
     // the DispatchSource if the socket is being watched for reads
@@ -114,13 +114,13 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
         }
         self.config = config
         self.address = address
-        self.closed = false
+        self.isClosed = false
 
         try setReuseAddress(true)
     }
     
     deinit {
-        // The socket needs to be closed (to close the underlying file descriptor). 
+        // The socket needs to be closed (to close the underlying file descriptor).
         // If descriptors aren't properly freed, the system will run out sooner or later.
         try? self.close()
     }
@@ -132,13 +132,13 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func connect() throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         let res = socket_connect(self.descriptor, address.raw, address.rawLen)
         guard res > -1 else { throw SocksError(.connectFailed) }
     }
 
     public func connect(withTimeout timeout: Double?) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
 
         guard let to = timeout else {
             try connect()
@@ -175,13 +175,13 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func listen(queueLimit: Int32 = 4096) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         let res = socket_listen(self.descriptor, queueLimit)
         guard res > -1 else { throw SocksError(.listenFailed) }
     }
 
     public func accept() throws -> TCPInternetSocket {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
         let addr = UnsafeMutablePointer<sockaddr_storage>.allocate(capacity: 1)
         let addrSockAddr = UnsafeMutablePointer<sockaddr>(OpaquePointer(addr))
@@ -201,14 +201,14 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
     }
 
     public func close() throws {
-        if closed { return }
+        if isClosed { return }
         stopWatching()
         if socket_close(self.descriptor) != 0 {
             throw SocksError(.closeSocketFailed)
         }
         // set descriptor to -1 to prevent further use
         self.descriptor = -1
-        closed = true
+        isClosed = true
     }
     
     /**
@@ -332,7 +332,7 @@ public class TCPInternetSocket: InternetSocket, TCPSocket, TCPReadableSocket, TC
 
 public class TCPEstablishedSocket: TCPSocket {
 
-    public let closed = false
+    public let isClosed = false
     public let descriptor: Descriptor
 
     public init(descriptor: Descriptor) {

--- a/Sources/SocksCore/UDPSocket.swift
+++ b/Sources/SocksCore/UDPSocket.swift
@@ -23,7 +23,7 @@ public class UDPInternetSocket: InternetSocket {
     public let descriptor: Descriptor
     public let config: SocketConfig
     public let address: ResolvedInternetAddress
-    public private(set) var closed = false
+    public private(set) var isClosed = false
 
     public required init(descriptor: Descriptor?, config: SocketConfig, address: ResolvedInternetAddress) throws {
 
@@ -49,7 +49,7 @@ public class UDPInternetSocket: InternetSocket {
     }
 
     public func recvfrom(maxBytes: Int = BufferCapacity) throws -> (data: [UInt8], sender: ResolvedInternetAddress) {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         let data = Bytes(capacity: maxBytes)
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
 
@@ -78,7 +78,7 @@ public class UDPInternetSocket: InternetSocket {
     }
 
     public func sendto(data: [UInt8], address: ResolvedInternetAddress? = nil) throws {
-        if closed { throw SocksError(.socketIsClosed) }
+        if isClosed { throw SocksError(.socketIsClosed) }
         let len = data.count
         let flags: Int32 = 0 //FIXME: allow setting flags with a Swift enum
         let destination = address ?? self.address
@@ -95,8 +95,8 @@ public class UDPInternetSocket: InternetSocket {
     }
 
     public func close() throws {
-        if closed { return }
-        closed = true
+        if isClosed { return }
+        isClosed = true
         if socket_close(self.descriptor) != 0 {
             throw SocksError(.closeSocketFailed)
         }


### PR DESCRIPTION
According to Swift API Design Guidelines,we might  use `isClosed` instead of `closed`.
So I renamed `closed` to `isClosed` ,and now the name `closed` is deprecated.
