### PR TITLE
add readn func to TCPReadableSocket

### DIFF
--- a/Tests/SocksCoreTests/PipeTests.swift
+++ b/Tests/SocksCoreTests/PipeTests.swift
@@ -41,5 +41,56 @@ class PipeTests: XCTestCase {
         
         try write.close()
     }
+    
+    func testReadnSimple() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        defer { try! read.close(); try! write.close() }
+        
+        let msg = "Hello Socket".toBytes()
+        try write.send(data: msg)
+        let inMsg = try read.readn(bytes: msg.count)
+        XCTAssertEqual(msg, inMsg)
+    }
+
+    func testReadnWith2Segment() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        defer { try! read.close(); try! write.close() }
+        
+        let msg_part1 = "Hello".toBytes()
+        let msg_part2 = "Socket".toBytes()
+       
+        try write.send(data: msg_part1)
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+            do{
+                try write.send(data: msg_part2)
+            }catch{
+                XCTFail("failed to send data")
+            }
+        }
+        let inMsg = try read.readn(bytes: msg_part1.count + msg_part2.count)
+        XCTAssertEqual(msg_part1 + msg_part2, inMsg)
+
+    }
+    
+    
+    func testReadnAndRemoteClosed() throws {
+        let (read, write) = try TCPEstablishedSocket.pipe()
+        
+        let msg_part1 = "Hello".toBytes()
+        let msg_part2 = "Socket".toBytes()
+        
+        try write.send(data: msg_part1)
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
+            do{
+                try write.close()
+            }catch{
+                XCTFail("failed close write socket")
+            }
+        }
+        let inMsg = try read.readn(bytes: msg_part1.count + msg_part2.count)
+        XCTAssertEqual(msg_part1, inMsg)
+        
+    }
+
 
 }

--- a/Tests/SocksCoreTests/PipeTests.swift
+++ b/Tests/SocksCoreTests/PipeTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Dispatch
 @testable import SocksCore
 
 class PipeTests: XCTestCase {
@@ -60,13 +61,15 @@ class PipeTests: XCTestCase {
         let msg_part2 = "Socket".toBytes()
        
         try write.send(data: msg_part1)
+        
         DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-            do{
+            do {
                 try write.send(data: msg_part2)
-            }catch{
+            }catch {
                 XCTFail("failed to send data")
             }
         }
+        
         let inMsg = try read.readn(bytes: msg_part1.count + msg_part2.count)
         XCTAssertEqual(msg_part1 + msg_part2, inMsg)
 
@@ -81,12 +84,13 @@ class PipeTests: XCTestCase {
         
         try write.send(data: msg_part1)
         DispatchQueue.global().asyncAfter(deadline: .now() + 2) {
-            do{
+            do {
                 try write.close()
-            }catch{
+            } catch {
                 XCTFail("failed close write socket")
             }
         }
+        
         let inMsg = try read.readn(bytes: msg_part1.count + msg_part2.count)
         XCTAssertEqual(msg_part1, inMsg)
         

--- a/Tests/SocksCoreTests/XCTestManifests.swift
+++ b/Tests/SocksCoreTests/XCTestManifests.swift
@@ -36,7 +36,10 @@ extension PipeTests {
         return [
             ("testSendAndReceive", testSendAndReceive),
             ("testNoData", testNoData),
-            ("testNoSIGPIPE", testNoSIGPIPE)
+            ("testNoSIGPIPE", testNoSIGPIPE),
+            ("testReadnSimple",testReadnSimple),
+            ("testReadnWith2Segment",testReadnWith2Segment),
+            ("testReadnAndRemoteClosed", testReadnAndRemoteClosed)
         ]
     }
 }


### PR DESCRIPTION
as TCP is a stream protocol, At many times, one data packet may be send within different segment.
so a readn func would help us a lot.
advices need to improve it.